### PR TITLE
Add synonym support

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -420,14 +420,26 @@ var sfnav = (function() {
                 if(key.toLowerCase().indexOf(tmpSplit[i].toLowerCase()) != -1)
                 {
                     match = true;
+                    sortValue = 1;
+                } 
+                
+                if(dict[key]['synonyms'] !== undefined){
+                    for(var j = 0;j<dict[key]['synonyms'].length;j++){
+                        keySynonym = dict[key]['synonyms'][j];
+                        if(keySynonym.toLowerCase().indexOf(tmpSplit[i].toLowerCase()) != -1)
+                        {
+                            match = true;
+                            sortValue = 0.5;
+                        }
+                    }
                 }
-                else
+                
+                if (!match)
                 {
-                    match = false;
                     break;
                 }
             }
-            if(match) arrFound.push({num : 1, key : key});
+            if(match) arrFound.push({num : sortValue, key : key});
         }
     }
     arrFound.sort(function(a,b) {
@@ -751,7 +763,6 @@ var sfnav = (function() {
         var act = {};
         metaData = {};
 
-
         for(var i=0;i<metadata.sobjects.length;i++)
         {
             if(metadata.sobjects[i].keyPrefix != null)
@@ -767,15 +778,16 @@ var sfnav = (function() {
                 act.key = metadata.sobjects[i].name;
                 act.keyPrefix = metadata.sobjects[i].keyPrefix;
                 act.url = serverInstance + '/' + metadata.sobjects[i].keyPrefix;
-
                 cmds['List ' + mRecord.labelPlural] = act;
+                cmds['List ' + mRecord.labelPlural]['synonyms'] = [metadata.sobjects[i].name];
+
                 act = {};
                 act.key = metadata.sobjects[i].name;
                 act.keyPrefix = metadata.sobjects[i].keyPrefix;
                 act.url = serverInstance + '/' + metadata.sobjects[i].keyPrefix;
                 act.url += '/e';
                 cmds['New ' + mRecord.label] = act;
-
+                cmds['New ' + mRecord.label]['synonyms'] = [metadata.sobjects[i].name];
 
             }
         }
@@ -1096,7 +1108,6 @@ var sfnav = (function() {
     });
 
     document.getElementById('sfnav_quickSearch').onkeyup = function() {
-
         lookAt();
         return true;
     }


### PR DESCRIPTION
This Pull Request adds support for synonyms for the "List" and "New" search words. This is useful when your Custom Object label differs from your Developer Name, for example:

Developer Name: Activity__c
Label: Task
Plural: Tasks

Currently, when searching for "Activity" you get:
Setup > Custom Object > Activity__c

With the addition of the synonyms, you will get:
Setup > Custom Object > Activity__c
New Task
List Tasks

I have given the synonym results a sort order of "0.5", which is below results that are a non-synonym match. This way, matches that are actually a visible direct match to the end user are prioritised.

This change is particularly useful for larger, more complex solutions where Custom Objects have been renamed over time - but the Developer Name could not be changed due to complexity.