### PR TITLE
Setting match to false before synonym check

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -422,14 +422,17 @@ var sfnav = (function() {
                     match = true;
                     sortValue = 1;
                 } 
-                
-                if(dict[key]['synonyms'] !== undefined){
-                    for(var j = 0;j<dict[key]['synonyms'].length;j++){
-                        keySynonym = dict[key]['synonyms'][j];
-                        if(keySynonym.toLowerCase().indexOf(tmpSplit[i].toLowerCase()) != -1)
-                        {
-                            match = true;
-                            sortValue = 0.5;
+                else 
+                {
+                    match = false;
+                    if(dict[key]['synonyms'] !== undefined){
+                        for(var j = 0;j<dict[key]['synonyms'].length;j++){
+                            keySynonym = dict[key]['synonyms'][j];
+                            if(keySynonym.toLowerCase().indexOf(tmpSplit[i].toLowerCase()) != -1)
+                            {
+                                match = true;
+                                sortValue = 0.5;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Setting to false so that a missing second word will set the match to false if no synonym found.