### PR TITLE
Can explicitly specify class/trigger/profile and go directly to it.

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -23,6 +23,11 @@ var sfnav = (function() {
   var SFAPI_VERSION = 'v33.0';
   var ftClient;
   var customObjects = {};
+  var apexClasses = {};
+  var triggers = {};
+  var profiles = {};
+  var pages = {};
+  var components = {};
   var META_DATATYPES = {
     "AUTONUMBER": {name:"AutoNumber",code:"auto", params:0},
     "CHECKBOX": {name:"Checkbox",code:"cb", params:0},
@@ -829,7 +834,11 @@ var sfnav = (function() {
     getSetupTree();
     // getCustomObjects();
     getCustomObjectsDef();
-
+    getApexClassesDef();
+    getTriggersDef();
+    getProfilesDef();
+    getPagesDef();
+    getComponentsDef();
   }
 
   function parseSetupTree(html)
@@ -1088,20 +1097,105 @@ var sfnav = (function() {
   {
 
     ftClient.query('Select+Id,+DeveloperName,+NamespacePrefix+FROM+CustomObject',
-      function(success)
-      {
-        for(var i=0;i<success.records.length;i++)
-          {
-            customObjects[success.records[i].DeveloperName.toLowerCase()] = {Id: success.records[i].Id};
-            var apiName = (success.records[i].NamespacePrefix == null ? '' : success.records[i].NamespacePrefix + '__') + success.records[i].DeveloperName + '__c';
-            cmds['Setup > Custom Object > ' + apiName] = {url: '/' + success.records[i].Id, key: apiName};
-          }
-      },
-      function(error)
-      {
-        getCustomObjects();
-      });
+    function(success)
+    {
+      for(var i=0;i<success.records.length;i++)
+        {
+          customObjects[success.records[i].DeveloperName.toLowerCase()] = {Id: success.records[i].Id};
+          var apiName = (success.records[i].NamespacePrefix == null ? '' : success.records[i].NamespacePrefix + '__') + success.records[i].DeveloperName + '__c';
+          cmds['Setup > Custom Object > ' + apiName] = {url: '/' + success.records[i].Id, key: apiName};
+        }
+    },
+    function(error)
+    {
+      getCustomObjects();
+    });
 
+  }
+  function getApexClassesDef() {
+    ftClient.query('Select+Id,+Name,+NamespacePrefix+FROM+ApexClass',
+    function(success)
+    {
+      for(var i=0;i<success.records.length;i++)
+        {
+          apexClasses[success.records[i].Name.toLowerCase()] = {Id: success.records[i].Id};
+          var apiName = (success.records[i].NamespacePrefix == null ? '' : success.records[i].NamespacePrefix + '__') + success.records[i].Name + '__c';
+          cmds['Setup > Apex Class > ' + apiName] = {url: '/' + success.records[i].Id, key: apiName};
+        }
+    },
+    function(error)
+    {
+      console.log('error while querying apex classes');
+      console.log('error =>> ', error);
+    });    
+  }
+  function getTriggersDef() {
+    ftClient.query('Select+Id,+Name+FROM+ApexTrigger',
+    function(success)
+    {
+      for(var i=0;i<success.records.length;i++)
+        {
+          triggers[success.records[i].Name.toLowerCase()] = {Id: success.records[i].Id};
+          var apiName = success.records[i].Name;
+          cmds['Setup > Apex Trigger > ' + apiName] = {url: '/' + success.records[i].Id, key: apiName};
+        }
+    },
+    function(error)
+    {
+      console.log('error while querying apex triggers');
+      console.log('error =>> ', error);
+    });
+  }
+  function getProfilesDef() {
+    ftClient.query('Select+Id,+Name+FROM+Profile',
+    function(success)
+    {
+      for(var i=0;i<success.records.length;i++)
+        {
+          profiles[success.records[i].Name.toLowerCase()] = {Id: success.records[i].Id};
+          var apiName = success.records[i].Name;
+          cmds['Setup > Profile > ' + apiName] = {url: '/' + success.records[i].Id, key: apiName};
+        }
+    },
+    function(error)
+    {
+      console.log('error while querying profiles');
+      console.log('error =>> ', error);
+    });   
+  }
+  function getPagesDef() {
+    ftClient.query('Select+Id,+Name+FROM+ApexPage',
+    function(success)
+    {
+      for(var i=0;i<success.records.length;i++)
+        {
+          pages[success.records[i].Name.toLowerCase()] = {Id: success.records[i].Id};
+          var apiName = success.records[i].Name;
+          cmds['Setup > Visualforce page > ' + apiName] = {url: '/' + success.records[i].Id, key: apiName};
+        }
+    },
+    function(error)
+    {
+      console.log('error while querying visualforce pages');
+      console.log('error =>> ', error);
+    });
+  }
+  function getComponentsDef() {
+    ftClient.query('Select+Id,+Name+FROM+ApexComponent',
+    function(success)
+    {
+      for(var i=0;i<success.records.length;i++)
+        {
+          components[success.records[i].Name.toLowerCase()] = {Id: success.records[i].Id};
+          var apiName = success.records[i].Name;
+          cmds['Setup > Visualforce component > ' + apiName] = {url: '/' + success.records[i].Id, key: apiName};
+        }
+    },
+    function(error)
+    {
+      console.log('error while querying visualforce components');
+      console.log('error =>> ', error);
+    });
   }
   function init()
   {

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -23,11 +23,6 @@ var sfnav = (function() {
   var SFAPI_VERSION = 'v33.0';
   var ftClient;
   var customObjects = {};
-  var apexClasses = {};
-  var triggers = {};
-  var profiles = {};
-  var pages = {};
-  var components = {};
   var META_DATATYPES = {
     "AUTONUMBER": {name:"AutoNumber",code:"auto", params:0},
     "CHECKBOX": {name:"Checkbox",code:"cb", params:0},
@@ -1118,7 +1113,6 @@ var sfnav = (function() {
     {
       for(var i=0;i<success.records.length;i++)
         {
-          apexClasses[success.records[i].Name.toLowerCase()] = {Id: success.records[i].Id};
           var apiName = (success.records[i].NamespacePrefix == null ? '' : success.records[i].NamespacePrefix + '__') + success.records[i].Name + '__c';
           cmds['Setup > Apex Class > ' + apiName] = {url: '/' + success.records[i].Id, key: apiName};
         }
@@ -1135,7 +1129,6 @@ var sfnav = (function() {
     {
       for(var i=0;i<success.records.length;i++)
         {
-          triggers[success.records[i].Name.toLowerCase()] = {Id: success.records[i].Id};
           var apiName = success.records[i].Name;
           cmds['Setup > Apex Trigger > ' + apiName] = {url: '/' + success.records[i].Id, key: apiName};
         }
@@ -1152,7 +1145,6 @@ var sfnav = (function() {
     {
       for(var i=0;i<success.records.length;i++)
         {
-          profiles[success.records[i].Name.toLowerCase()] = {Id: success.records[i].Id};
           var apiName = success.records[i].Name;
           cmds['Setup > Profile > ' + apiName] = {url: '/' + success.records[i].Id, key: apiName};
         }
@@ -1169,7 +1161,6 @@ var sfnav = (function() {
     {
       for(var i=0;i<success.records.length;i++)
         {
-          pages[success.records[i].Name.toLowerCase()] = {Id: success.records[i].Id};
           var apiName = success.records[i].Name;
           cmds['Setup > Visualforce page > ' + apiName] = {url: '/' + success.records[i].Id, key: apiName};
         }
@@ -1186,7 +1177,6 @@ var sfnav = (function() {
     {
       for(var i=0;i<success.records.length;i++)
         {
-          components[success.records[i].Name.toLowerCase()] = {Id: success.records[i].Id};
           var apiName = success.records[i].Name;
           cmds['Setup > Visualforce component > ' + apiName] = {url: '/' + success.records[i].Id, key: apiName};
         }


### PR DESCRIPTION
extension now allows to get not only LIST of Apex classes/Triggers/Profiles/Visualforce pages/Visualforce Components, but pick explicitly needed entity by name. So, I.e. if you have a class named AccountHandler - you just write "AccountHandler" in SalesforceNavigator search and click "Enter" to get redirected directly to this class.